### PR TITLE
Crytical bug fix + change of variables in loss function 

### DIFF
--- a/software/.vscode/launch.json
+++ b/software/.vscode/launch.json
@@ -16,6 +16,18 @@
             "sourceFileMap": {
                 "/proc/self/cwd/": "${workspaceFolder}",
               },
+            "setupCommands": [
+                {
+                    "description": "Test",
+                    "text": "python import sys;sys.path.insert(0, '/usr/share/gcc/python');from libstdcxx.v6.printers import register_libstdcxx_printers;register_libstdcxx_printers(None)",
+                    "ignoreFailures": false
+                },
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]              
         }
     ]
 }

--- a/software/BUILD
+++ b/software/BUILD
@@ -374,6 +374,7 @@ cc_binary(
     "pimodel_binary_test.cc"
   ],
   deps = [
-    ":pimodel"
+    ":pimodel",
+    ":utils"
   ]
 )

--- a/software/model.cc
+++ b/software/model.cc
@@ -1,13 +1,18 @@
 #include "model.h"
 
+#include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <iostream>
+#include <random>
 #include <sstream>
 #include <unordered_set>
 #include <vector>
 
 #include "maybe.h"
 #include "utils.h"
+
+auto rng = std::default_random_engine{};
 
 const double MIN_STEP_IMPROVEMENT =
     0.0;  // min relative improvement to early stop
@@ -20,7 +25,7 @@ void Model::GradientDescentStep(int i, double stepSize) {
     std::vector<double> newParameters =
         std::vector<double>(this->nParameters());
 
-    std::vector<double> grad = this->ResidueGradient(i);
+    std::vector<double> grad = this->LossGradient(i);
     assert(grad.size() == oldParameters.size());
     for (int i = 0; i < int(oldParameters.size()); i++) {
         newParameters[i] = oldParameters[i] - grad[i] * stepSize;
@@ -32,10 +37,99 @@ void Model::GradientDescentStep(int i, double stepSize) {
 double Model::Loss() {
     double l = 0;
     for (int i = 0; i < this->nResidues(); i++) {
-        l += this->Residue(i);
+        l += pow(this->Residue(i), 2);
     }
     return l;
 }
+
+// Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
+//                            bool log) {
+//     Maybe<double> r;
+//     if (learningRate <= 0) {
+//         r.isError = true;
+//         r.errMsg = "LearningRate must be >0";
+//         return r;
+//     }
+//     auto precision = std::cout.precision();
+
+//     batchSize = std::min(batchSize, this->nResidues());
+
+//     double lossBeforeStep = this->Loss();
+//     if (log) {
+//         std::cout.precision(20);
+//         std::cout << "Initial Loss: " << lossBeforeStep << std::endl;
+//     }
+//     double lossAfterStep;
+//     bool stepOk;
+
+//     std::vector<double> parametersBeforeStep =
+//         std::vector<double>(this->nParameters());
+//     int step = 0;
+//     while (step < maxSteps && learningRate != 0 && lossBeforeStep > 0) {
+//         auto stepStart = Now();
+//         this->GetParameters(&parametersBeforeStep);
+
+//         auto start = Now();
+//         std::unordered_set<int> batch;
+//         int tries = 0;
+//         const int maxTriesToCreateRandomBatch = 10;
+//         while (batch.size() < batchSize &&
+//                tries < maxTriesToCreateRandomBatch) {
+//             batch.insert(RandomInt(0, this->nResidues() - 1));
+//             tries += 1;
+//         }
+//         int i = 0;
+//         while (batch.size() < batchSize) {
+//             batch.insert(i);
+//             i++;
+//         }
+//         if (log) {
+//             std::cout << "Time to create batch: " << TimeSince(start)
+//                       << std::endl;
+//         }
+
+//         for (int residueIndex : batch) {
+//             start = Now();
+//             this->GradientDescentStep(residueIndex, learningRate);
+//             if (log) {
+//                 std::cout << "Time for SGD step: " << TimeSince(start)
+//                           << std::endl;
+//             }
+//         }
+//         start = Now();
+//         lossAfterStep = this->Loss();
+//         if (log) {
+//             std::cout << "Time to compute loss after epoch batch "
+//                       << TimeSince(start) << std::endl;
+//         }
+//         stepOk = lossAfterStep < lossBeforeStep;
+//         if (!stepOk) {
+//             // If the step did not reduce the loss, we reset to the initial
+//             // conditions and reduce the learning rate
+//             lossAfterStep = lossBeforeStep;
+//             this->SetParameters(&parametersBeforeStep);
+//             learningRate /= 2;
+//         } else {
+//             // If it was ok, we update the "before" values to prepare for the
+//             // next step
+//             lossBeforeStep = lossAfterStep;
+//         }
+//         if (log) {
+//             std::cout << "Step time: " << TimeSince(stepStart) << std::endl;
+//             std::cout.precision(20);
+//             std::cout << "Loss: " << lossAfterStep;
+//             std::cout.precision(3);
+//             std::cout << " Learning Rate: " << learningRate;
+//             stepOk ? std::cout << " -> Step Ok"
+//                    : std::cout << " -> Step Not Ok ";
+//             std::cout << std::endl;
+//         }
+//         step++;
+//     }
+//     std::cout.precision(precision);
+//     r.val = lossAfterStep;
+//     return r;
+// }
 
 Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
                            bool log) {
@@ -45,67 +139,23 @@ Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
         r.errMsg = "LearningRate must be >0";
         return r;
     }
-    auto precision = std::cout.precision();
-
-    batchSize = std::min(batchSize, this->nResidues());
-
-    double lossBeforeStep = this->Loss();
-    if (log) {
-        std::cout.precision(20);
-        std::cout << "Initial Loss: " << lossBeforeStep << std::endl;
-        ;
-    }
-    double lossAfterStep;
-    bool stepOk;
 
     std::vector<double> parametersBeforeStep =
         std::vector<double>(this->nParameters());
     int step = 0;
-    while (step < maxSteps && learningRate != 0 && lossBeforeStep > 0) {
+    while (step < maxSteps) {
         this->GetParameters(&parametersBeforeStep);
 
-        std::unordered_set<int> batch;
-        int tries = 0;
-        const int maxTriesToCreateRandomBatch = 10;
-        while (batch.size() < batchSize &&
-               tries < maxTriesToCreateRandomBatch) {
-            batch.insert(RandomInt(0, this->nResidues() - 1));
-            tries += 1;
-        }
-        int i = 0;
-        while (batch.size() < batchSize) {
-            batch.insert(i);
-            i++;
-        }
-        for (int residueIndex : batch) {
-            this->GradientDescentStep(residueIndex, learningRate);
-        }
-
-        lossAfterStep = this->Loss();
-        stepOk = lossAfterStep < lossBeforeStep;
-        if (!stepOk) {
-            // If the step did not reduce the loss, we reset to the initial
-            // conditions and reduce the learning rate
-            lossAfterStep = lossBeforeStep;
-            this->SetParameters(&parametersBeforeStep);
-            learningRate /= 2;
-        } else {
-            // If it was ok, we update the "before" values to prepare for the
-            // next step
-            lossBeforeStep = lossAfterStep;
-        }
+        this->GradientDescentStep(RandomInt(0, this->nResidues() - 1),
+                                  learningRate);
         if (log) {
-            std::cout.precision(20);
-            std::cout << "Loss: " << lossAfterStep;
-            std::cout.precision(3);
-            std::cout << " Learning Rate: " << learningRate;
-            stepOk ? std::cout << " -> Step Ok"
-                   : std::cout << " -> Step Not Ok ";
-            std::cout << std::endl;
+            std::cout << "Loss: " << this->Loss() << std::endl;
         }
         step++;
+        if (this->Loss() <= 0.000001) {
+            break;
+        }
     }
-    std::cout.precision(precision);
-    r.val = lossAfterStep;
+    r.val = this->Loss();
     return r;
 }

--- a/software/model.cc
+++ b/software/model.cc
@@ -17,7 +17,7 @@ auto rng = std::default_random_engine{};
 const double MIN_STEP_IMPROVEMENT =
     0.0;  // min relative improvement to early stop
 
-void Model::GradientDescentStep(int i, double stepSize) {
+void Model::StochasticGradientDescentStep(int i, double stepSize) {
     std::vector<double> oldParameters =
         std::vector<double>(this->nParameters());
     this->GetParameters(&oldParameters);
@@ -42,95 +42,6 @@ double Model::Loss() {
     return l;
 }
 
-// Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
-//                            bool log) {
-//     Maybe<double> r;
-//     if (learningRate <= 0) {
-//         r.isError = true;
-//         r.errMsg = "LearningRate must be >0";
-//         return r;
-//     }
-//     auto precision = std::cout.precision();
-
-//     batchSize = std::min(batchSize, this->nResidues());
-
-//     double lossBeforeStep = this->Loss();
-//     if (log) {
-//         std::cout.precision(20);
-//         std::cout << "Initial Loss: " << lossBeforeStep << std::endl;
-//     }
-//     double lossAfterStep;
-//     bool stepOk;
-
-//     std::vector<double> parametersBeforeStep =
-//         std::vector<double>(this->nParameters());
-//     int step = 0;
-//     while (step < maxSteps && learningRate != 0 && lossBeforeStep > 0) {
-//         auto stepStart = Now();
-//         this->GetParameters(&parametersBeforeStep);
-
-//         auto start = Now();
-//         std::unordered_set<int> batch;
-//         int tries = 0;
-//         const int maxTriesToCreateRandomBatch = 10;
-//         while (batch.size() < batchSize &&
-//                tries < maxTriesToCreateRandomBatch) {
-//             batch.insert(RandomInt(0, this->nResidues() - 1));
-//             tries += 1;
-//         }
-//         int i = 0;
-//         while (batch.size() < batchSize) {
-//             batch.insert(i);
-//             i++;
-//         }
-//         if (log) {
-//             std::cout << "Time to create batch: " << TimeSince(start)
-//                       << std::endl;
-//         }
-
-//         for (int residueIndex : batch) {
-//             start = Now();
-//             this->GradientDescentStep(residueIndex, learningRate);
-//             if (log) {
-//                 std::cout << "Time for SGD step: " << TimeSince(start)
-//                           << std::endl;
-//             }
-//         }
-//         start = Now();
-//         lossAfterStep = this->Loss();
-//         if (log) {
-//             std::cout << "Time to compute loss after epoch batch "
-//                       << TimeSince(start) << std::endl;
-//         }
-//         stepOk = lossAfterStep < lossBeforeStep;
-//         if (!stepOk) {
-//             // If the step did not reduce the loss, we reset to the initial
-//             // conditions and reduce the learning rate
-//             lossAfterStep = lossBeforeStep;
-//             this->SetParameters(&parametersBeforeStep);
-//             learningRate /= 2;
-//         } else {
-//             // If it was ok, we update the "before" values to prepare for the
-//             // next step
-//             lossBeforeStep = lossAfterStep;
-//         }
-//         if (log) {
-//             std::cout << "Step time: " << TimeSince(stepStart) << std::endl;
-//             std::cout.precision(20);
-//             std::cout << "Loss: " << lossAfterStep;
-//             std::cout.precision(3);
-//             std::cout << " Learning Rate: " << learningRate;
-//             stepOk ? std::cout << " -> Step Ok"
-//                    : std::cout << " -> Step Not Ok ";
-//             std::cout << std::endl;
-//         }
-//         step++;
-//     }
-//     std::cout.precision(precision);
-//     r.val = lossAfterStep;
-//     return r;
-// }
-
 Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
                            bool log) {
     Maybe<double> r;
@@ -146,14 +57,18 @@ Maybe<double> Model::Train(double learningRate, int batchSize, int maxSteps,
     while (step < maxSteps) {
         this->GetParameters(&parametersBeforeStep);
 
-        this->GradientDescentStep(RandomInt(0, this->nResidues() - 1),
-                                  learningRate);
-        if (log) {
-            std::cout << "Loss: " << this->Loss() << std::endl;
-        }
+        this->StochasticGradientDescentStep(RandomInt(0, this->nResidues() - 1),
+                                            learningRate);
         step++;
-        if (this->Loss() <= 0.000001) {
-            break;
+        // Compute loss only every now and then to improve efficiency because
+        // computing the whole loss can be expensive.
+        if (step % 50 == 0) {
+            if (log) {
+                std::cout << "Loss: " << this->Loss() << std::endl;
+            }
+            if (this->Loss() <= 0.000001) {
+                break;
+            }
         }
     }
     r.val = this->Loss();

--- a/software/model.h
+++ b/software/model.h
@@ -20,7 +20,7 @@ class Model {
     Maybe<double> Train(double learningRate, int batchSize, int maxSteps,
                         bool log);
 
-    // Returns the total loss, i.e. the mean squared error
+    // Returns the total loss, i.e. the sum of the squared residues
     double Loss();
 
    private:
@@ -34,21 +34,21 @@ class Model {
 
     // Returns the value of the i-th residue given the model's current
     // parameters.
-    // Ex: loss = 1/2*((model(x0)-y0)^2 + (model(x1)-y1)^2))
-    // Loss(0) -> (model(x0)-y0)^2
-    // Loss(1) -> (model(x1)-y1)^2)
+    // Ex: loss = ((model(x0)-y0)^2 + (model(x1)-y1)^2))
+    // Residue(0) -> model(x0)-y0
+    // Residue(1) -> model(x1)-y1
     virtual double Residue(int i) = 0;
 
     // Returns the number of residues in the loss
-    // Ex: loss = 1/2*(model(x0)-y0)^2 + (model(x1) - y1)^2 -> 2 residues
+    // Ex: loss = (model(x0)-y0)^2 + (model(x1) - y1)^2 -> 2 residues
     virtual int nResidues() = 0;
 
-    // Returns the gradient of the i-th residue with respect to the model's
+    // Returns the gradient of the i-th loss summand with respect to the model's
     // parameters i.e. if the model has 2 parameters, the returned vector will
-    // be the derivative of the loss function with respect to the first
-    // parameter followed by the derivative of the loss function with respect to
-    // the second parameter
-    virtual std::vector<double> ResidueGradient(int i) = 0;
+    // be the derivative of the i-th squared residue with respect to the first
+    // parameter followed by the derivative of the i-th
+    // squared residue with respect to the second parameter.
+    virtual std::vector<double> LossGradient(int i) = 0;
 
     // Performs a step in gradient descent considering the i-th residue. If the
     // value of the residue decreases, returns true and its value. Else, resets

--- a/software/model.h
+++ b/software/model.h
@@ -47,7 +47,10 @@ class Model {
     // parameters i.e. if the model has 2 parameters, the returned vector will
     // be the derivative of the i-th squared residue with respect to the first
     // parameter followed by the derivative of the i-th
-    // squared residue with respect to the second parameter.
+    // squared residue with respect to the second parameter. It's fine if
+    // multiplicative constants are removed. I.e. returning [1,5] if the formal
+    // mathematical gradient is [2,10] is absolutely fine, because we scale
+    // the gradient anyways during training.
     virtual std::vector<double> LossGradient(int i) = 0;
 
     // Performs a step in gradient descent considering the i-th residue. If the

--- a/software/model.h
+++ b/software/model.h
@@ -55,7 +55,7 @@ class Model {
     // the parameters to what they previously were, and returns false and the
     // residue's value before the step. The step parameter is what
     // multiplies the gradient: Parameters_new = Parameters_old - step*grad
-    void GradientDescentStep(int i, double stepSize);
+    void StochasticGradientDescentStep(int i, double stepSize);
 
     FRIEND_TEST(ModelTest, LossTest);
 };

--- a/software/model.h
+++ b/software/model.h
@@ -53,11 +53,8 @@ class Model {
     // the gradient anyways during training.
     virtual std::vector<double> LossGradient(int i) = 0;
 
-    // Performs a step in gradient descent considering the i-th residue. If the
-    // value of the residue decreases, returns true and its value. Else, resets
-    // the parameters to what they previously were, and returns false and the
-    // residue's value before the step. The step parameter is what
-    // multiplies the gradient: Parameters_new = Parameters_old - step*grad
+    // Performs a step in gradient descent considering the i-th residue. Note:
+    // does not guarantee that the overall loss will decrease.
     void StochasticGradientDescentStep(int i, double stepSize);
 
     FRIEND_TEST(ModelTest, LossTest);

--- a/software/model_test.cc
+++ b/software/model_test.cc
@@ -70,8 +70,7 @@ class TestModel : public Model {
 
     FRIEND_TEST(ModelTest, LossTest);
     double Residue(int i) override {
-        // Standard quadratic loss
-        // L = Sum ( (model(xi)-yi)^2 )
+        // (model(xi)-yi)
         double l;
         std::vector<double> X;
 
@@ -81,22 +80,22 @@ class TestModel : public Model {
         // 2 | 71
         if (i == 0) {
             X = {0};
-            l = pow((*this)(&X).val - (5), 2);
+            l = (*this)(&X).val - (5);
         }
         if (i == 1) {
             X = {1};
-            l = pow((*this)(&X).val - (25), 2);
+            l = (*this)(&X).val - (25);
         }
         if (i == 2) {
             X = {2};
-            l = pow((*this)(&X).val - (71), 2);
+            l = (*this)(&X).val - (71);
         }
 
         return l;
     };
 
     FRIEND_TEST(ModelTest, LossGradientTest);
-    std::vector<double> ResidueGradient(int i) override {
+    std::vector<double> LossGradient(int i) override {
         // model(x) = ax^2 + bx + c
         // Li = (model(xi)-yi)^2
         // dLi/da = 2*(model(xi)-yi)* dModel(xi)/da
@@ -220,7 +219,7 @@ TEST(ModelTest, LossGradientTest) {
     // 0 | 5
     // 1 | 25
     // 2 | 71
-    auto lossGrad = m.ResidueGradient(0);
+    auto lossGrad = m.LossGradient(0);
     double da = 2 * (a * 0.0 * 0.0 + b * 0.0 + c - 5) * 0.0 * 0.0;
     double db = 2 * (a * 0.0 * 0.0 + b * 0.0 + c - 5) * 0.0;
     double dc = 2 * (a * 0.0 * 0.0 + b * 0.0 + c - 5) * 1;
@@ -228,7 +227,7 @@ TEST(ModelTest, LossGradientTest) {
     ASSERT_DOUBLE_EQ(db, lossGrad[1]);
     ASSERT_DOUBLE_EQ(dc, lossGrad[2]);
 
-    lossGrad = m.ResidueGradient(1);
+    lossGrad = m.LossGradient(1);
     da = 2 * (a * 1.0 * 1.0 + b * 1.0 + c - 25) * 1.0 * 1.0;
     db = 2 * (a * 1.0 * 1.0 + b * 1.0 + c - 25) * 1.0;
     dc = 2 * (a * 1.0 * 1.0 + b * 1.0 + c - 25) * 1;
@@ -236,7 +235,7 @@ TEST(ModelTest, LossGradientTest) {
     ASSERT_DOUBLE_EQ(db, lossGrad[1]);
     ASSERT_DOUBLE_EQ(dc, lossGrad[2]);
 
-    lossGrad = m.ResidueGradient(2);
+    lossGrad = m.LossGradient(2);
     da = 2 * (a * 2.0 * 2.0 + b * 2.0 + c - 71) * 2.0 * 2.0;
     db = 2 * (a * 2.0 * 2.0 + b * 2.0 + c - 71) * 2.0;
     dc = 2 * (a * 2.0 * 2.0 + b * 2.0 + c - 71) * 1;
@@ -248,7 +247,7 @@ TEST(ModelTest, LossGradientTest) {
 TEST(ModelTest, TrainTest) {
     TestModel m = TestModel();
     auto status = m.Train(0.01, 3, 2000, true);
-    ASSERT_TRUE(RelativeAbsError(m.a, 13) < 0.001);
-    ASSERT_TRUE(RelativeAbsError(m.b, 7) < 0.001);
-    ASSERT_TRUE(RelativeAbsError(m.c, 5) < 0.001);
+    ASSERT_TRUE(RelativeAbsError(m.a, 13) < 0.01);
+    ASSERT_TRUE(RelativeAbsError(m.b, 7) < 0.01);
+    ASSERT_TRUE(RelativeAbsError(m.c, 5) < 0.01);
 }

--- a/software/pimodel.cc
+++ b/software/pimodel.cc
@@ -233,29 +233,6 @@ Problem Pimodel::problemFromTkc(std::vector<Bounded>* tkc) {
     return problem.val;
 }
 
-std::vector<double> Pimodel::getXModel(std::vector<Bounded>* tkc) {
-    // X: State vector. Displacements followed by velocities.
-    auto X = std::vector<double>(this->p.NumberOfMasses() * 2);
-
-    Maybe<Void> err;
-    Maybe<double> eval;
-    for (int massId = 0; massId < this->nMasses; massId++) {
-        // Fill displacements
-        this->models(massId, 0).SetX(Bounded::Get(*tkc));
-        eval = this->models(massId, 0)(this->modelsCoefficients[massId]);
-        assert(!eval.isError);
-        X[massId] = eval.val;
-
-        // Fill velocities
-        this->modelsD[massId].SetX(Bounded::Get(*tkc));
-        eval = this->modelsD[massId](this->modelsCoefficients[massId]);
-        assert(!eval.isError);
-        X[Problem::GetMassVelIndex(this->p.NumberOfMasses(), massId)] =
-            eval.val;
-    }
-    return X;
-}
-
 bst::matrix<Polys> Pimodel::getAccelsFromDiffEq(Problem* problem,
                                                 std::vector<Bounded>& tkc) {
     // List of displacements and velocities
@@ -415,11 +392,11 @@ void Pimodel::AddPhysicsResidues() {
 }
 
 Polys* Pimodel::residueById(int i) {
-    if (i < this->initialDispResidues.size()) {
+    if (i < int(this->initialDispResidues.size())) {
         return &(this->initialDispResidues[i]);
     }
     i -= this->initialDispResidues.size();
-    if (i < this->initialVelResidues.size()) {
+    if (i < int(this->initialVelResidues.size())) {
         return &(this->initialVelResidues[i]);
     }
     i -= this->initialVelResidues.size();
@@ -427,11 +404,11 @@ Polys* Pimodel::residueById(int i) {
 }
 
 std::map<std::tuple<int, int>, double>* Pimodel::residueDaById(int i) {
-    if (i < this->initialDispResidues.size()) {
+    if (i < int(this->initialDispResidues.size())) {
         return &(this->initialDispResiduesDa[i]);
     }
     i -= this->initialDispResidues.size();
-    if (i < this->initialVelResidues.size()) {
+    if (i < int(this->initialVelResidues.size())) {
         return &(this->initialVelResiduesDa[i]);
     }
     i -= this->initialVelResidues.size();
@@ -585,21 +562,22 @@ void Pimodels::logComplexity() {
 
     // Initial displacement residues cost
     int n = 0;
-    for (int i = 0; i < this->pimodels[0].initialDispResidues.size(); i++) {
+    for (int i = 0; i < int(this->pimodels[0].initialDispResidues.size());
+         i++) {
         n += this->pimodels[0].initialDispResidues[i].nMonomials();
     }
     std::cout << "Total cost of calculating initial displacement residues:" << n
               << std::endl;
     // Initial velocities residues cost
     n = 0;
-    for (int i = 0; i < this->pimodels[0].initialVelResidues.size(); i++) {
+    for (int i = 0; i < int(this->pimodels[0].initialVelResidues.size()); i++) {
         n += this->pimodels[0].initialVelResidues[i].nMonomials();
     }
     std::cout << "Total cost of calculating initial velocity residues:" << n
               << std::endl;
     // Physics residues cost
     n = 0;
-    for (int i = 0; i < this->pimodels[0].physicsResidues.size(); i++) {
+    for (int i = 0; i < int(this->pimodels[0].physicsResidues.size()); i++) {
         n += this->pimodels[0].physicsResidues[i].nMonomials();
     }
     std::cout << "Total cost of calculating physics residues:" << n

--- a/software/pimodel.h
+++ b/software/pimodel.h
@@ -213,5 +213,4 @@ class Pimodels {
     FRIEND_TEST(PimodelsTest, getContinuityTkcTest);
     FRIEND_TEST(PimodelsTest, setContinuityTest);
     FRIEND_TEST(PimodelsTest, OperatorTest);
-    FRIEND_TEST(PimodelTest, PhysicsLoss3MassesTest);
 };

--- a/software/pimodel.h
+++ b/software/pimodel.h
@@ -30,10 +30,12 @@ class Pimodel : public Model {
 
     // Returns the position of each mass.
     // The input should be an array with:
-    // The time
+    // The global time
     // The values of the springs
     // The values of the dampers
-    // U = [t, k1, k2, ... , kn, c1, c2, ... , cn]
+    // U = [T, K1, K2, ... , Kn, C1, C2, ... , Cn]
+    // All inputs are NOT normalized (i.e. they don't have to be in [0, 1]).
+    // E.g. of valid input: U = [100.0, 99.0, ...]
     Maybe<std::vector<double>> operator()(std::vector<double>* TKC);
     // Similar to operator(), but returns the velocity of each mass
     Maybe<std::vector<double>> GetVelocities(std::vector<double>* TKC);
@@ -81,9 +83,9 @@ class Pimodel : public Model {
     // masses.
     boost::numeric::ublas::matrix<Poly> models;
     std::vector<std::vector<double>> modelsCoefficients;
-    // Derivatives of each model with respect to time
+    // Derivatives of each model with respect to t (normalized time)
     std::vector<Poly> modelsD;
-    // Second derivatives of each model with respect to time
+    // Second derivatives of each model with respect to t (normalized time)
     std::vector<Poly> modelsDD;
 
     // Residues of initial displacement
@@ -118,8 +120,10 @@ class Pimodel : public Model {
     // This model describes the system from t = t0 to t = t1
     double t0;
     double t1;
-    // Derivative of "t" (normalized time from [0,1]) w.r.t. T ("regular" time)
+    // Derivative of t (normalized time from [0,1]) w.r.t. T (global time)
     double dtdT;
+    // Derivative of T (global time) w.r.t. t (normalized time from [0,1])
+    double dTdt;
 
     // Parameter that describes in how many intervals we'll discretize time and
     // the springs/dampers values in our loss function

--- a/software/pimodel.h
+++ b/software/pimodel.h
@@ -118,6 +118,8 @@ class Pimodel : public Model {
     // This model describes the system from t = t0 to t = t1
     double t0;
     double t1;
+    // Derivative of "t" (normalized time from [0,1]) w.r.t. T ("regular" time)
+    double dtdT;
 
     // Parameter that describes in how many intervals we'll discretize time and
     // the springs/dampers values in our loss function

--- a/software/pimodel.h
+++ b/software/pimodel.h
@@ -62,6 +62,7 @@ class Pimodel : public Model {
     FRIEND_TEST(PimodelTest, PhysicsResiduesTest);
     FRIEND_TEST(PimodelTest, nResiduesTest);
     FRIEND_TEST(PimodelTest, LossTest);
+    FRIEND_TEST(PimodelTest, PhysicsLoss3MassesTest);
     FRIEND_TEST(PimodelTest, LossGradientTest);
     FRIEND_TEST(PimodelsTest, ConstructorTest);
     FRIEND_TEST(PimodelsTest, setContinuityTest);
@@ -151,7 +152,7 @@ class Pimodel : public Model {
     double Residue(int i) override;
     // AddResidues must be called first for this to work properly
     int nResidues() override;
-    std::vector<double> ResidueGradient(int i) override;
+    std::vector<double> LossGradient(int i) override;
 
     // Auxiliary functions:
 
@@ -210,4 +211,5 @@ class Pimodels {
     FRIEND_TEST(PimodelsTest, getContinuityTkcTest);
     FRIEND_TEST(PimodelsTest, setContinuityTest);
     FRIEND_TEST(PimodelsTest, OperatorTest);
+    FRIEND_TEST(PimodelTest, PhysicsLoss3MassesTest);
 };

--- a/software/pimodel.h
+++ b/software/pimodel.h
@@ -61,10 +61,10 @@ class Pimodel : public Model {
     FRIEND_TEST(PimodelTest, PhysicsResiduesTkcTest);
     FRIEND_TEST(PimodelTest, PhysicsResiduesTkcZeroDiscTest);
     FRIEND_TEST(PimodelTest, InitialConditionsResiduesTest);
+    FRIEND_TEST(PimodelTest, InitialConditionsResiduesNumericalTest);
     FRIEND_TEST(PimodelTest, PhysicsResiduesTest);
+    FRIEND_TEST(PimodelTest, PhysicsResiduesNumericalTest);
     FRIEND_TEST(PimodelTest, nResiduesTest);
-    FRIEND_TEST(PimodelTest, LossTest);
-    FRIEND_TEST(PimodelTest, PhysicsLoss3MassesTest);
     FRIEND_TEST(PimodelTest, LossGradientTest);
     FRIEND_TEST(PimodelsTest, ConstructorTest);
     FRIEND_TEST(PimodelsTest, setContinuityTest);
@@ -167,10 +167,6 @@ class Pimodel : public Model {
 
     // Return the state vector with the initial conditions set
     std::vector<double> getInitialX();
-
-    // Calculate the state vector for given tkc (time, springs and dampers)
-    // using the polynomials
-    std::vector<double> getXModel(std::vector<Bounded>* tkc);
 
     // Gets the polynomials that represent the acceleration of each mass
     // by using the differential equation from the discrete element method

--- a/software/pimodel_binary_test.cc
+++ b/software/pimodel_binary_test.cc
@@ -32,15 +32,15 @@ int main(int argc, char *argv[]) {
     assert(pd.IsOk());
 
     // Learning parameters
-    double finalT = 0.04;
-    int nModels = 2;
-    int timeDiscretization = 1;
+    double finalT = 0.05;
+    int nModels = 20;
+    int timeDiscretization = 2;
     int kcDiscretization = 0;
     int order = 3;
-    double learningRate = 0.0001;
+    double learningRate = 0.01;
     int batchSize = 5;
-    int maxSteps = 5000;
-    bool log = false;
+    int maxSteps = 500;
+    bool log = true;
 
     // Train all models
     Pimodels models = Pimodels(pd, finalT, nModels, timeDiscretization,

--- a/software/pimodel_binary_test.cc
+++ b/software/pimodel_binary_test.cc
@@ -1,4 +1,5 @@
 #include "pimodel.h"
+#include "utils.h"
 
 int main(int argc, char *argv[]) {
     ProblemDescription pd = ProblemDescription();
@@ -27,24 +28,26 @@ int main(int argc, char *argv[]) {
     pd.AddSpring(4, 5, min, max);  // k45
     pd.AddDamper(4, 5, min, max);  // c45
     pd.SetFixedMass(0);
-    pd.AddInitialVel(200.0);  // initial speed
+    pd.AddInitialVel(200.0);  // initial vel
     assert(pd.IsOk());
 
     // Learning parameters
-    double finalT = 0.05;
-    int nModels = 3;
+    double finalT = 0.04;
+    int nModels = 2;
     int timeDiscretization = 1;
     int kcDiscretization = 0;
     int order = 3;
-    double learningRate = 0.1;
-    int batchSize = 1000;
-    int maxSteps = 2000;
+    double learningRate = 0.0001;
+    int batchSize = 5;
+    int maxSteps = 5000;
     bool log = false;
 
     // Train all models
     Pimodels models = Pimodels(pd, finalT, nModels, timeDiscretization,
                                kcDiscretization, order);
+    auto start = Now();
     assert(!models.Train(learningRate, batchSize, maxSteps, log).isError);
+    std::cout << "Time to train model: " << TimeSince(start) << std::endl;
 
     // Get problem using intermediate value for k and c, and integrate it.
     double mean = (min + max) / 2;
@@ -53,11 +56,17 @@ int main(int argc, char *argv[]) {
                             mean, mean, mean, mean, mean, mean, mean});
     assert(!mP.isError);
     Problem p = mP.val;
+    start = Now();
     assert(!p.Integrate(finalT).isError);
+    std::cout << "Time to integrate: " << TimeSince(start) << std::endl;
 
     std::vector<double> tkc =
         std::vector<double>{0.0,  mean, mean, mean, mean, mean, mean, mean,
                             mean, mean, mean, mean, mean, mean, mean, mean};
+    start = Now();
+    models(&tkc);
+    std::cout << "Time to estimate with model: " << TimeSince(start)
+              << std::endl;
     Maybe<std::vector<double>> X;
     Maybe<std::vector<double>> XDot;
     std::cout << "t,x5,x5Dot,modelX5,modelX5Dot" << std::endl;

--- a/software/pimodel_test.cc
+++ b/software/pimodel_test.cc
@@ -788,19 +788,19 @@ TEST_F(PimodelTest, PhysicsResiduesNumericalTest) {
     // d²/dT²(x1)
     auto d2_x1_dT2 = [](double m1, double k1, double k2, double k3, double c1,
                         double c2, double c3, double x0, double x1, double x2,
-                        double x0Dot, double x1Dot, double x2Dot) {
+                        double dx0dT, double dx1dT, double dx2dT) {
         return 1.0 / m1 *
-               (k1 * (x0 - x1) + c1 * (x0Dot - x1Dot) + k3 * (x2 - x1) +
-                c3 * (x2Dot - x1Dot));
+               (k1 * (x0 - x1) + c1 * (dx0dT - dx1dT) + k3 * (x2 - x1) +
+                c3 * (dx2dT - dx1dT));
     };
 
     // d²/dT²(x2)
     auto d2_x2_dT2 = [](double m2, double k1, double k2, double k3, double c1,
                         double c2, double c3, double x0, double x1, double x2,
-                        double x0Dot, double x1Dot, double x2Dot) {
+                        double dx0dT, double dx1dT, double dx2dT) {
         return 1.0 / m2 *
-               (k2 * (x0 - x2) + c2 * (x0Dot - x2Dot) + k3 * (x1 - x2) +
-                c3 * (x1Dot - x2Dot));
+               (k2 * (x0 - x2) + c2 * (dx0dT - dx2dT) + k3 * (x1 - x2) +
+                c3 * (dx1dT - dx2dT));
     };
 
     // Residues:
@@ -905,8 +905,8 @@ TEST_F(PimodelTest, nResiduesTest) {
     //   for c in (0,1):
     //     x0Model(t=0,k,c) - x0_t=0
     //     x1Model(t=0,k,c) - x1_t=0
-    //     x0ModelDot(t=0,k,c) - x0Dot_t=0
-    //     x1ModelDot(t=0,k,c) - x1Dot_t=0
+    //     x0ModelDot(t=0,k,c) - dx0dT_t=0
+    //     x1ModelDot(t=0,k,c) - dx1dT_t=0
     // -> 2*2*4 = 16 residues
     //
     // TimeDiscretization = 1 -> residues will be evaluated for t = 0 and t=1
@@ -915,9 +915,9 @@ TEST_F(PimodelTest, nResiduesTest) {
     // for t in (0, 1):
     //   for k in (0, 1):
     //     for c in (0, 1):
-    //       x0ModelDotDot(t,k,c) - x0DotDot(x0Model(t,k,c),
+    //       x0ModelDotDot(t,k,c) - d²x0dT²(x0Model(t,k,c),
     //       x0ModelDot(t,k,c))
-    //       x1ModelDotDot(t,k,c) - x1DotDot(x1Model(t,k,c),
+    //       x1ModelDotDot(t,k,c) - d²x1dT²(x1Model(t,k,c),
     //       x1ModelDot(t,k,c))
     // -> 2*2*2*2 = 16 residues
     ASSERT_EQ(model_.nResidues(), 16 + 16);

--- a/software/polynomial.cc
+++ b/software/polynomial.cc
@@ -122,6 +122,7 @@ Maybe<Void> Poly::Build(int n, int order, bool tiny, int id) {
     }
 
     this->id = id;
+    this->dxCount = 0;
     this->n = n;
     this->X = std::vector<double>(n);
 
@@ -362,7 +363,7 @@ Maybe<Void> Poly::Dxi(int i) {
             return r;
         }
     }
-
+    this->dxCount += 1;
     return r;
 }
 

--- a/software/polynomial.h
+++ b/software/polynomial.h
@@ -55,6 +55,9 @@ class Poly {
     // Used to order polynomial coefficients when calculating gradient of
     // linear combination of Poly instances (see Polys class)
     int id;
+    // Used to identify the number of times this instance was differentiated,
+    // i.e. how many times Dxi was called. Mostly used for debugging.
+    int dxCount;
 
     // Number of variables
     // P = x^2 + xy + x + y^2 + y + 1 -> n = 2

--- a/software/utils.cc
+++ b/software/utils.cc
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 #include <random>
@@ -82,3 +83,14 @@ Maybe<double> NormalizeToDouble(double val, double min, double max) {
 double Unnormalize(Bounded b, double min, double max) {
     return min + b.Get() * (max - min);
 };
+
+std::chrono::_V2::system_clock::time_point Now() {
+    return std::chrono::high_resolution_clock::now();
+}
+
+std::string TimeSince(std::chrono::_V2::system_clock::time_point start) {
+    auto ms =
+        std::chrono::duration_cast<std::chrono::microseconds>(Now() - start)
+            .count();
+    return std::to_string(ms) + " us";
+}

--- a/software/utils.h
+++ b/software/utils.h
@@ -45,3 +45,9 @@ Maybe<double> NormalizeToDouble(double val, double min, double max);
 
 // "Unnormalizes" value to unbounded interval
 double Unnormalize(Bounded b, double min, double max);
+
+// Convenience function to get current time
+std::chrono::_V2::system_clock::time_point Now();
+
+// Convenient function to get readable time difference from t0 to now
+std::string TimeSince(std::chrono::_V2::system_clock::time_point t0);


### PR DESCRIPTION
This PR does mainly twhe following:

### Fixes crytical bug in residues
The `Residue` was returning the square of the residue, not the residue itself. This caused error to blowup and training to be super slow.

### Change formulation
Now the `Residues` are in terms of `local t` (normalized time) as opposed to global `T`.

### Fix SGD
Stochastic gradient descent was wrong; it was trying to do batch SGD but that also wasn't WAI. This fixes it. Also, the loss is only calculated every now and then so that the SGD is in fact much more efficient than GD.

### Impact
Training is working awesomely well :)
Seems like this will in fact work and we can get some perf improvements.